### PR TITLE
Remove default SHOP_DEPARTMENTSTORE

### DIFF
--- a/test/conf/OSM_tags_POI_classification.yml
+++ b/test/conf/OSM_tags_POI_classification.yml
@@ -163,7 +163,7 @@ railway=
     station=subway TRANSPORT_SUBWAY
   =tram_stop TRANSPORT_TRAMSTOP
    
-shop= SHOP_DEPARTMENTSTORE
+shop=   
   =alcohol SHOP_ALCOHOL
   =antiques SHOP_ART
   =appliance SHOP_APPLIANCE


### PR DESCRIPTION
Currently unmapped shop values (including  `shop=vacant`) are being classed as `SHOP_DEPARTMENTSTORE`.